### PR TITLE
[fr] Correct "Sepia light" translation

### DIFF
--- a/content-server/fr.po
+++ b/content-server/fr.po
@@ -3938,7 +3938,7 @@ msgstr "Noir"
 
 #: /__w/calibre/calibre/src/pyj/read_book/globals.pyj:64
 msgid "Sepia light"
-msgstr "Sépia léger"
+msgstr "Sépia clair"
 
 #: /__w/calibre/calibre/src/pyj/read_book/globals.pyj:65
 msgid "Sepia dark"


### PR DESCRIPTION
When it comes to colorschemes, "light" means "clair", not "léger"